### PR TITLE
Reverse the animation when paused instead of freezing it

### DIFF
--- a/lib/mini_music_visualizer.dart
+++ b/lib/mini_music_visualizer.dart
@@ -135,6 +135,7 @@ class _VisualComponentState extends State<VisualComponent>
 
   void pause() {
     animationController.stop();
+    animationController.reverse();
   }
 
   void update() {


### PR DESCRIPTION
As stated in the title, when the "animate" parameter is set to false, it's going to reverse it to the beginning instead of freezing it.
